### PR TITLE
getChunk instead of parseChunk

### DIFF
--- a/core/components/login/controllers/web/ChangePassword.php
+++ b/core/components/login/controllers/web/ChangePassword.php
@@ -354,10 +354,10 @@ class LoginChangePasswordController extends LoginController {
         $errors = $this->errors;
         if (!empty($errors)) {
             foreach ($errors as $error) {
-                $errorOutput .= $this->modx->parseChunk($errTpl,  array('msg' => $error));
+                $errorOutput .= $this->modx->getChunk($errTpl,  array('msg' => $error));
             }
         } else {
-            $errorOutput = $this->modx->parseChunk($errTpl, array('msg' => $defaultErrorMessage));
+            $errorOutput = $this->modx->getChunk($errTpl, array('msg' => $defaultErrorMessage));
         }
         return $errorOutput;
     }

--- a/core/components/login/controllers/web/Login.php
+++ b/core/components/login/controllers/web/Login.php
@@ -224,7 +224,7 @@ class LoginLoginController extends LoginController {
             $this->modx->toPlaceholders($this->preHooks->getErrors(),$this->getProperty('errorPrefix','error'));
 
             $errorMsg = $this->preHooks->getErrorMessage();
-            $errorOutput = $this->modx->parseChunk($this->getProperty('errTpl'), array('msg' => $errorMsg));
+            $errorOutput = $this->modx->getChunk($this->getProperty('errTpl'), array('msg' => $errorMsg));
             $this->modx->setPlaceholder('errors',$errorOutput);
             $success = false;
         }
@@ -260,12 +260,12 @@ class LoginLoginController extends LoginController {
         $message = $response->getMessage();
         if (!empty($errors)) {
             foreach ($errors as $error) {
-                $errorOutput .= $this->modx->parseChunk($errTpl, $error);
+                $errorOutput .= $this->modx->getChunk($errTpl, $error);
             }
         } elseif (!empty($message)) {
-            $errorOutput = $this->modx->parseChunk($errTpl, array('msg' => $message));
+            $errorOutput = $this->modx->getChunk($errTpl, array('msg' => $message));
         } else {
-            $errorOutput = $this->modx->parseChunk($errTpl, array('msg' => $defaultErrorMessage));
+            $errorOutput = $this->modx->getChunk($errTpl, array('msg' => $defaultErrorMessage));
         }
         return $errorOutput;
     }
@@ -382,7 +382,7 @@ class LoginLoginController extends LoginController {
             $this->modx->toPlaceholders($this->preHooks->getErrors(),$this->getProperty('errorPrefix','error'));
 
             $errorMsg = $this->preHooks->getErrorMessage();
-            $errorOutput = $this->modx->parseChunk($this->getProperty('errTpl'), array('msg' => $errorMsg));
+            $errorOutput = $this->modx->getChunk($this->getProperty('errTpl'), array('msg' => $errorMsg));
             $this->modx->setPlaceholder('errors',$errorOutput);
             $success = false;
         }


### PR DESCRIPTION
I experienced missing pieces from templates with parseChunk.
Using getChunk solved the issue.

opengeek (MODX Staff) wrote:
"In Revo there is not much difference, other than the placeholders with parseChunk are only set for the scope of the call."
"I suppose parseChunk might be useful in certain situations, but it was originally kept there only for backwards compatibility with Evo API calls."

References
http://forums.modx.com/thread/35455/parsechunk-or-setplaceholder-w-getchunk
http://forums.modx.com/thread/75790/output-modifiers-parsechunk-and-getchunk
