### PR TITLE
Fix update form fields

### DIFF
--- a/core/components/login/controllers/web/UpdateProfile.php
+++ b/core/components/login/controllers/web/UpdateProfile.php
@@ -71,7 +71,7 @@ class LoginUpdateProfileController extends LoginController {
         if (!$this->getUser()) return '';
         if (!$this->getProfile()) return '';
         
-        $this->setFieldPlaceholders();
+        
         $this->checkForSuccessMessage();
         if ($this->hasPost()) {
             $this->loadDictionary();
@@ -92,6 +92,7 @@ class LoginUpdateProfileController extends LoginController {
                 }
             }
         }
+        $this->setFieldPlaceholders();
         return '';
     }
 


### PR DESCRIPTION
Fix update form fields with new values when "reloadOnSuccess=0"
If we are have update form on page after submit values we are have old values received from profile.
We are need to update fields with new values after submit their values in user profile
