### PR TITLE
[[!+error.message]] should return detailed error

### DIFF
--- a/core/components/login/controllers/web/UpdateProfile.php
+++ b/core/components/login/controllers/web/UpdateProfile.php
@@ -202,6 +202,12 @@ class LoginUpdateProfileController extends LoginController {
             $placeholderPrefix = $this->getProperty('placeholderPrefix');
             $this->modx->toPlaceholders($this->validator->getErrors(),$placeholderPrefix.'error');
             $this->modx->toPlaceholders($this->dictionary->toArray(),$placeholderPrefix);
+            $errors = array();
+			$es = $this->validator->getErrors();
+			foreach ($es as $key => $error) {
+				$errors['message'] .= $error . '<br>';
+			}
+			$this->modx->toPlaceholder('message', $errors['message'], $placeholderPrefix.'error');
         } else {
             $validated = true;
         }


### PR DESCRIPTION
Currently it is returning static error from lexicon "$this->modx->lexicon('login.profile_err_save');" ONLY on successfull "$this->validate()"

This commit return [[!+error.message]] from "$this->validate()" upon failed validation.