### PR TITLE
Replace addSessionContexts before OnUserActivate

### DIFF
--- a/core/components/login/controllers/web/ConfirmRegister.php
+++ b/core/components/login/controllers/web/ConfirmRegister.php
@@ -61,12 +61,12 @@ class LoginConfirmRegisterController extends LoginController {
             return '';
         }
         
+        $this->addSessionContexts();
+        
         /* invoke OnUserActivate event */
         $this->modx->invokeEvent('OnUserActivate',array(
             'user' => &$this->user,
         ));
-
-        $this->addSessionContexts();
 
         $this->redirectBack();
         return '';


### PR DESCRIPTION
Move 'addSessionContexts ' call before 'invoke OnUserActivate event'. It'll be much better, when you want to redirect page (with already logged-in user) using Plugin with 'OnUserActivate' event.

Without above change, 'addSessionContexts' will never fired, when you redirect page in Plugin with OnUserActivate event.