### PR TITLE
Fixes the problem with double urlencoding which prevents activation of some users + also fixes the problem that the cachepwd field isn't emptied

### DIFF
--- a/core/components/login/controllers/web/ConfirmRegister.php
+++ b/core/components/login/controllers/web/ConfirmRegister.php
@@ -55,7 +55,7 @@ class LoginConfirmRegisterController extends LoginController {
 
         /* activate user */
         $this->user->set('active',1);
-        $this->user->_setRaw('cachepwd','')
+        $this->user->_setRaw('cachepwd','');
         
         if (!$this->user->save()) {
             $this->modx->log(modX::LOG_LEVEL_ERROR,'[Register] Could not save activated user: '.$this->user->get('username'));

--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -328,18 +328,4 @@ class Login {
         }
         return $success;
     }
-
-    /**
-     * Helper method to empty users cachepwd field.
-     *
-     * @access public
-     * @param integer $userID
-     * @return void
-     */
-    public function emptyCachePwd($userID) {
-        $table = $this->modx->getTableName('modUser');
-        $sql = "UPDATE {$table} SET `cachepwd`='' WHERE id=".$userID;
-        $stmt = $this->modx->prepare($sql);
-        $stmt->execute();
-    }
 }


### PR DESCRIPTION
This fixes the problem with double urlencoding which prevents activation of some users.
And it also fixes the problem that the cachepwd field isn't emptied when a user is activated.