### PR TITLE
Fixed empty cachepwd field in activation process (again, ... sorry!)

### DIFF
--- a/core/components/login/controllers/web/ConfirmRegister.php
+++ b/core/components/login/controllers/web/ConfirmRegister.php
@@ -55,12 +55,14 @@ class LoginConfirmRegisterController extends LoginController {
 
         /* activate user */
         $this->user->set('active',1);
-        $this->user->_setRaw('cachepwd','');
         
         if (!$this->user->save()) {
             $this->modx->log(modX::LOG_LEVEL_ERROR,'[Register] Could not save activated user: '.$this->user->get('username'));
             return '';
         }
+
+        /* Empty the users cachepwd */
+        $this->login->emptyCachePwd($this->user->get('id'));
 
         /* invoke OnUserActivate event */
         $this->modx->invokeEvent('OnUserActivate',array(

--- a/core/components/login/docs/changelog.txt
+++ b/core/components/login/docs/changelog.txt
@@ -1,5 +1,7 @@
 Changelog file for Login component.
 
+- Fixed empty cachepwd field in activation process (again, ... sorry!)
+
 Login 1.9.1
 ====================================
 - [[!+error.message]] returns detailed error

--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -328,4 +328,18 @@ class Login {
         }
         return $success;
     }
+
+    /**
+     * Helper method to empty users cachepwd field.
+     *
+     * @access public
+     * @param integer $userID
+     * @return void
+     */
+    public function emptyCachePwd($userID) {
+        $table = $this->modx->getTableName('modUser');
+        $sql = "UPDATE {$table} SET `cachepwd`='' WHERE id=".$userID;
+        $stmt = $this->modx->prepare($sql);
+        $stmt->execute();
+    }
 }


### PR DESCRIPTION
The problem is, the original: $this->user->set('cachepwd',''); doesn't work as this generates a hash of an empty value and the cachepwd field isn't emptied.

This is a problem in the MODX core and needs to be fixed.

My first fix (previous PR), using the _setRaw method also doesn't work in some cases, as this method is protected.

Signed-off-by: gadgetto <rij-Ub-eiD-yab-Yak-Ek>