### PR TITLE
Fix sending register activation email

### DIFF
--- a/core/components/login/processors/register.php
+++ b/core/components/login/processors/register.php
@@ -257,7 +257,7 @@ class LoginRegisterProcessor extends LoginProcessor {
         $emailProperties = $this->gatherActivationEmailProperties();
 
         /* send either to user's email or a specified activation email */
-        $activationEmail = $this->controller->getProperty('activationEmail',$this->user->get('email'));
+        $activationEmail = $this->controller->getProperty('activationEmail',$this->profile->get('email'));
         $subject = $this->controller->getProperty('activationEmailSubject',$this->modx->lexicon('register.activation_email_subject'));
         return $this->login->sendEmail($activationEmail,$this->user->get('username'),$subject,$emailProperties);
     }


### PR DESCRIPTION
Hello!

My name is Sergey, i'm developing into modx revo.

In last project i need to add registering users. Users created successfully, but email activation is not sended because "mail_err_unset_spec" error occured (core/model/modx/mail/modphpmailer.class.php:152 revo 2.2.14).

I find this code into Login register processor (core/components/login/processors/register.php:260):

/* send either to user's email or a specified activation email */
$activationEmail = $this->controller->getProperty('activationEmail',$this->user->get('email'));

But $this->user is instance of modUser and has no email field.

I think it's a bug and code must be like this:

/* send either to user's email or a specified activation email */
$activationEmail = $this->controller->getProperty('activationEmail',$this->profile->get('email'));

This bug is already long enough open (http://tracker.modx.com/issues/10279).