### PR TITLE
Added activePage property to ConfirmRegister processor

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -3,7 +3,7 @@
   "lowCaseName": "login",
   "description": "Login and Registrations",
   "author": "Jason Coward & Shaun McCormick",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "package": {
     "elements": {
       "snippets": [
@@ -174,6 +174,11 @@
             {
               "name": "errorPage",
               "description": "prop_confirmregister.errorpage_desc",
+              "value": ""
+            },
+            {
+              "name": "activePage",
+              "description": "prop_confirmregister.activepage_desc",
               "value": ""
             }
           ]

--- a/core/components/login/controllers/web/ActiveUsers.php
+++ b/core/components/login/controllers/web/ActiveUsers.php
@@ -66,7 +66,7 @@ class LoginActiveUsersController extends LoginController {
         
         $sortBy = $this->modx->getOption('sortBy',$_REQUEST,$this->getProperty('sortBy','username'));
         $sortDir = $this->modx->getOption('sortDir',$_REQUEST,$this->getProperty('sortDir','DESC'));
-        $limit = $this->modx->getOption('limit',$_REQUEST,$this->getProperty('limit',10,'isset'));
+        $limit = $this->modx->getOption('limit',$_REQUEST,$this->getProperty('limit',10));
         $offset = $this->modx->getOption('offset',$_REQUEST,$this->getProperty('offset',0));
         
         $c = $this->modx->newQuery($classKey);
@@ -122,9 +122,9 @@ class LoginActiveUsersController extends LoginController {
      * @return string
      */
     public function output(array $list = array()) {
-        $outputSeparator = $this->getProperty('outputSeparator',"\n",'isset');
+        $outputSeparator = $this->getProperty('outputSeparator',"\n");
         $output = implode($outputSeparator,$list);
-        $toPlaceholder = $this->getProperty('toPlaceholder','','isset');
+        $toPlaceholder = $this->getProperty('toPlaceholder','');
         if (!empty($toPlaceholder)) {
             $this->modx->toPlaceholder($toPlaceholder,$output);
             return '';

--- a/core/components/login/controllers/web/ChangePassword.php
+++ b/core/components/login/controllers/web/ChangePassword.php
@@ -81,7 +81,7 @@ class LoginChangePasswordController extends LoginController {
                 'username' => $this->modx->user->get('username'),
                 'id' => $this->modx->user->get('id'),
             ));
-            $this->modx->setPlaceholders($placeholders,$this->getProperty('placeholderPrefix','logcp.'));
+            $this->modx->toPlaceholders($placeholders, rtrim($this->getProperty('placeholderPrefix', 'logcp.'), '.'));
         }
         return $this->profile;
     }
@@ -188,9 +188,9 @@ class LoginChangePasswordController extends LoginController {
      * @return void
      */
     public function setToPlaceholders() {
-        $placeholderPrefix = $this->getProperty('placeholderPrefix','logcp.');
-        $this->modx->setPlaceholders($this->errors,$placeholderPrefix.'error.');
-        $this->modx->setPlaceholders($this->dictionary->toArray(),$placeholderPrefix);
+        $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix', 'logcp.'), '.');
+        $this->modx->toPlaceholders($this->errors, $placeholderPrefix . '.error');
+        $this->modx->toPlaceholders($this->dictionary->toArray(), $placeholderPrefix);
     }
 
     /**
@@ -217,9 +217,9 @@ class LoginChangePasswordController extends LoginController {
         }
         /* process preHooks */
         if ($this->preHooks->hasErrors()) {
-            $placeholderPrefix = $this->getProperty('placeholderPrefix','logcp.');
-            $this->modx->setPlaceholders($this->preHooks->getErrors(),$placeholderPrefix.'error.');
-            $this->modx->setPlaceholder($placeholderPrefix.'error_message',$this->preHooks->getErrorMessage());
+            $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix', 'logcp.'), '.');
+            $this->modx->toPlaceholders($this->preHooks->getErrors(), $placeholderPrefix . '.error');
+            $this->modx->setPlaceholder($placeholderPrefix . '.error_message', $this->preHooks->getErrorMessage());
             $passed = false;
         }
         return $passed;
@@ -297,7 +297,7 @@ class LoginChangePasswordController extends LoginController {
     public function loadPostHooks() {
         $postHooks = $this->getProperty('postHooks','');
         if (!empty($postHooks)) {
-            $placeholderPrefix = $this->getProperty('placeholderPrefix');
+            $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix'), '.');
             $this->loadHooks('postHooks');
             $fields['changepassword.user'] = &$this->modx->user;
             $fields['changepassword.profile'] =& $this->profile;
@@ -308,10 +308,10 @@ class LoginChangePasswordController extends LoginController {
 
             /* process post hooks errors */
             if ($this->postHooks->hasErrors()) {
-                $this->modx->setPlaceholders($this->postHooks->getErrors(),$placeholderPrefix.'error.');
+                $this->modx->toPlaceholders($this->postHooks->getErrors(), $placeholderPrefix . '.error');
 
                 $errorMsg = $this->postHooks->getErrorMessage();
-                $this->modx->setPlaceholder($placeholderPrefix.'error_message',$errorMsg);
+                $this->modx->setPlaceholder($placeholderPrefix . '.error_message', $errorMsg);
             }
         }
     }

--- a/core/components/login/controllers/web/ChangePassword.php
+++ b/core/components/login/controllers/web/ChangePassword.php
@@ -94,7 +94,7 @@ class LoginChangePasswordController extends LoginController {
         $verified = true;
         /* verify authenticated status */
         if (!$this->modx->user->hasSessionContext($this->modx->context->get('key'))) {
-            if ($this->getProperty('redirectToLogin',true,'isset')) {
+            if ($this->getProperty('redirectToLogin',true)) {
                 $this->modx->sendUnauthorizedPage();
             }
             $verified = false;
@@ -163,7 +163,7 @@ class LoginChangePasswordController extends LoginController {
         $placeholderPrefix = $this->getProperty('placeholderPrefix');
         $fieldNewPassword = $this->getProperty('fieldNewPassword');
         $fieldOldPassword = $this->getProperty('fieldOldPassword');
-        $validateOldPassword = $this->getProperty('validateOldPassword',true,'isset');
+        $validateOldPassword = $this->getProperty('validateOldPassword',true);
         $newPassword = $this->dictionary->get($fieldNewPassword);
         $oldPassword = $this->dictionary->get($fieldOldPassword);
 
@@ -232,7 +232,7 @@ class LoginChangePasswordController extends LoginController {
     public function validateOldPassword() {
         $validated = true;
         /* if changing the password */
-        if ($this->getProperty('validateOldPassword',true,'isset')) {
+        if ($this->getProperty('validateOldPassword',true)) {
             $fields = $this->dictionary->toArray();
             $fieldOldPassword = $this->getProperty('fieldOldPassword','password_old');
             
@@ -321,7 +321,7 @@ class LoginChangePasswordController extends LoginController {
      * @return mixed
      */
     public function reloadOnSuccess() {
-        $reloadOnSuccess = $this->getProperty('reloadOnSuccess',true,'isset');
+        $reloadOnSuccess = $this->getProperty('reloadOnSuccess',true);
         if ($reloadOnSuccess) {
             /* if reloading the page after success */
             $url = $this->modx->makeUrl($this->modx->resource->get('id'),'',array(

--- a/core/components/login/controllers/web/ConfirmRegister.php
+++ b/core/components/login/controllers/web/ConfirmRegister.php
@@ -99,18 +99,21 @@ class LoginConfirmRegisterController extends LoginController {
      */
     public function getUser() {
         $this->user = $this->modx->getObject('modUser',array('username' => $this->username));
-        if ($this->user == null || $this->user->get('active')) {
+        if ($this->user == null) {
             $this->redirectAfterFailure();
+        } elseif ($this->user->get('active')) {
+            $activePage = $this->getProperty('activePage', false, 'isset');
+            $this->redirectAfterFailure($activePage);
         }
         return $this->user;
     }
 
     /**
      * Handle the redirection after a failed verification
-     * @return void
+     * @param mixed $id Resource ID to redirect to - defa
      */
-    public function redirectAfterFailure() {
-        $errorPage = $this->getProperty('errorPage',false,'isset');
+    public function redirectAfterFailure($id = null) {
+        $errorPage = (is_null($id)) ? $this->getProperty('errorPage', false, 'isset') : $id;
         if (!empty($errorPage)) {
             $url = $this->modx->makeUrl($errorPage,'','','full');
             $this->modx->sendRedirect($url);

--- a/core/components/login/controllers/web/ConfirmRegister.php
+++ b/core/components/login/controllers/web/ConfirmRegister.php
@@ -102,7 +102,7 @@ class LoginConfirmRegisterController extends LoginController {
         if ($this->user == null) {
             $this->redirectAfterFailure();
         } elseif ($this->user->get('active')) {
-            $activePage = $this->getProperty('activePage', false, 'isset');
+            $activePage = $this->getProperty('activePage', false);
             $this->redirectAfterFailure($activePage);
         }
         return $this->user;
@@ -113,7 +113,7 @@ class LoginConfirmRegisterController extends LoginController {
      * @param mixed $id Resource ID to redirect to - defa
      */
     public function redirectAfterFailure($id = null) {
-        $errorPage = (is_null($id)) ? $this->getProperty('errorPage', false, 'isset') : $id;
+        $errorPage = (is_null($id)) ? $this->getProperty('errorPage', false) : $id;
         if (!empty($errorPage)) {
             $url = $this->modx->makeUrl($errorPage,'','','full');
             $this->modx->sendRedirect($url);
@@ -168,7 +168,7 @@ class LoginConfirmRegisterController extends LoginController {
      * @return void
      */
     public function addSessionContexts() {
-        if ($this->getProperty('authenticate',true,'isset')) {
+        if ($this->getProperty('authenticate',true)) {
             $this->modx->user =& $this->user;
             $this->modx->getUser();
             $contexts = $this->getProperty('authenticateContexts',$this->modx->context->get('key'));
@@ -186,7 +186,7 @@ class LoginConfirmRegisterController extends LoginController {
      * to a form requiring registration
      */
     public function redirectBack() {
-        $redirectBack = $this->modx->getOption('redirectBack',$_REQUEST,$this->getProperty('redirectBack',false,'isset'));
+        $redirectBack = $this->modx->getOption('redirectBack',$_REQUEST,$this->getProperty('redirectBack',false));
         $redirectBackParams = $this->modx->getOption('redirectBackParams',$_REQUEST,$this->getProperty('redirectBackParams',''));
         if (!empty($redirectBackParams)) {
             $redirectBackParams = $this->login->decodeParams($redirectBackParams);
@@ -199,7 +199,7 @@ class LoginConfirmRegisterController extends LoginController {
             if (empty($redirectParams) || !is_array($redirectParams)) $redirectParams = array();
 
             /* handle persist params from Register snippet */
-            $redirectUnsetDefaultParams = (boolean) $this->getProperty('redirectUnsetDefaultParams', 0, 'isset');
+            $redirectUnsetDefaultParams = (boolean) $this->getProperty('redirectUnsetDefaultParams', 0);
 			if(!$redirectUnsetDefaultParams) {
                 $persistParams = $_GET;
                 unset($persistParams['lp'],$persistParams['lu'],$persistParams['id']);

--- a/core/components/login/controllers/web/ForgotPassword.php
+++ b/core/components/login/controllers/web/ForgotPassword.php
@@ -236,7 +236,7 @@ class LoginForgotPasswordController extends LoginController {
      * @return boolean
      */
     public function checkForRedirect() {
-        $redirectTo = $this->getProperty('redirectTo',false,'isset');
+        $redirectTo = $this->getProperty('redirectTo',false);
         /* if redirecting, do so here */
         if (!empty($redirectTo)) {
             $redirectParams = $this->getProperty('redirectParams','');

--- a/core/components/login/controllers/web/Login.php
+++ b/core/components/login/controllers/web/Login.php
@@ -75,7 +75,7 @@ class LoginLoginController extends LoginController {
      * @return string
      */
     public function renderForm() {
-        $redirectToPrior = $this->getProperty('redirectToPrior',false,'isset');
+        $redirectToPrior = $this->getProperty('redirectToPrior',false);
         $tpl = $this->isAuthenticated ? $this->getProperty('logoutTpl') : $this->getProperty('loginTpl');
         $actionMsg = $this->isAuthenticated
             ? $this->getProperty('logoutMsg',$this->modx->lexicon('login.logout'))
@@ -279,7 +279,7 @@ class LoginLoginController extends LoginController {
      * @return void
      */
     public function checkForRedirectOnFailedAuth(modProcessorResponse $response) {
-        $redirectToOnFailedAuth = $this->getProperty('redirectToOnFailedAuth',false,'isset');
+        $redirectToOnFailedAuth = $this->getProperty('redirectToOnFailedAuth',false);
         if ($redirectToOnFailedAuth && $redirectToOnFailedAuth != $this->modx->resource->get('id')) {
             $p = array(
                 'u' => $this->dictionary->get('username'),

--- a/core/components/login/controllers/web/Profile.php
+++ b/core/components/login/controllers/web/Profile.php
@@ -91,7 +91,7 @@ class LoginProfileController extends LoginController {
      */
     public function getExtended() {
         $extended = array();
-        if ($this->getProperty('useExtended',true,'isset')) {
+        if ($this->getProperty('useExtended',true)) {
             $extended = $this->profile->get('extended');
         }
         return (array) $extended;
@@ -116,7 +116,7 @@ class LoginProfileController extends LoginController {
      * @return boolean|modUser
      */
     public function getUser() {
-        $user = $this->getProperty('user',false,'isset');
+        $user = $this->getProperty('user',false);
 
         /* verify authenticated status if no user specified */
         if (empty($user) && !$this->modx->user->hasSessionContext($this->modx->context->get('key'))) {

--- a/core/components/login/controllers/web/Profile.php
+++ b/core/components/login/controllers/web/Profile.php
@@ -62,10 +62,16 @@ class LoginProfileController extends LoginController {
      */
     public function setToPlaceholders() {
         $placeholders = array_merge($this->profile->toArray(),$this->user->toArray());
+        $placeholderPrefix = $this->getProperty('prefix', '', 'isset');
         $extended = $this->getExtended();
         $placeholders = array_merge($extended,$placeholders);
         $placeholders = $this->removePasswordPlaceholders($placeholders);
-        $this->modx->toPlaceholders($placeholders,$this->getProperty('prefix','','isset'),'');
+        $this->modx->toPlaceholders($placeholders, $placeholderPrefix, '');
+        foreach ($placeholders as $k => $v) {
+            if (is_array($v)) {
+                $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
+            }
+        }
         return $placeholders;
     }
 

--- a/core/components/login/controllers/web/Profile.php
+++ b/core/components/login/controllers/web/Profile.php
@@ -62,14 +62,14 @@ class LoginProfileController extends LoginController {
      */
     public function setToPlaceholders() {
         $placeholders = array_merge($this->profile->toArray(),$this->user->toArray());
-        $placeholderPrefix = $this->getProperty('prefix', '', 'isset');
+        $placeholderPrefix = rtrim($this->getProperty('prefix', ''), '.');
         $extended = $this->getExtended();
         $placeholders = array_merge($extended,$placeholders);
         $placeholders = $this->removePasswordPlaceholders($placeholders);
-        $this->modx->toPlaceholders($placeholders, $placeholderPrefix, '');
+        $this->modx->toPlaceholders($placeholders, $placeholderPrefix);
         foreach ($placeholders as $k => $v) {
             if (is_array($v)) {
-                $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
+                $this->modx->setPlaceholder($placeholderPrefix . '.' . $k, json_encode($v));
             }
         }
         return $placeholders;

--- a/core/components/login/controllers/web/Register.php
+++ b/core/components/login/controllers/web/Register.php
@@ -123,10 +123,12 @@ class LoginRegisterController extends LoginController {
         }
 
         $placeholders = $this->dictionary->toArray();
+        $this->modx->setPlaceholders($placeholders, $placeholderPrefix);
         foreach ($placeholders as $k => $v) {
-            if (is_array($v)) $placeholders[$k] = json_encode($v);
+            if (is_array($v)) {
+                $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
+            }
         }
-        $this->modx->setPlaceholders($placeholders,$placeholderPrefix);
         return '';
     }
 

--- a/core/components/login/controllers/web/Register.php
+++ b/core/components/login/controllers/web/Register.php
@@ -122,7 +122,11 @@ class LoginRegisterController extends LoginController {
             }
         }
 
-        $this->modx->setPlaceholders($this->dictionary->toArray(),$placeholderPrefix);
+        $placeholders = $this->dictionary->toArray();
+        foreach ($placeholders as $k => $v) {
+            if (is_array($v)) $placeholders[$k] = json_encode($v);
+        }
+        $this->modx->setPlaceholders($placeholders,$placeholderPrefix);
         return '';
     }
 

--- a/core/components/login/controllers/web/Register.php
+++ b/core/components/login/controllers/web/Register.php
@@ -87,13 +87,13 @@ class LoginRegisterController extends LoginController {
         $this->dictionary->fromArray($fields);
 
         $this->validateUsername();
-        if ($this->getProperty('validatePassword',true,'isset')) {
+        if ($this->getProperty('validatePassword', true)) {
             $this->validatePassword();
         }
-        if ($this->getProperty('ensurePasswordStrength',false,'isset')) {
+        if ($this->getProperty('ensurePasswordStrength', false)) {
             $this->ensurePasswordStrength();
         }
-        if ($this->getProperty('generatePassword',false,'isset')) {
+        if ($this->getProperty('generatePassword', false)) {
             $this->generatePassword();
         }
         $this->validateEmail();
@@ -188,7 +188,7 @@ class LoginRegisterController extends LoginController {
             $alreadyExists = $this->modx->getObject('modUser',array('username' => $username));
             if ($alreadyExists) {
                 $cachePwd = $alreadyExists->get('cachepwd');
-                if ($this->getProperty('removeExpiredRegistrations',true,'isset') && $alreadyExists->get('active') == 0 && !empty($cachePwd)) {
+                if ($this->getProperty('removeExpiredRegistrations',true) && $alreadyExists->get('active') == 0 && !empty($cachePwd)) {
                     /* if inactive and has a cachepwd, probably an expired
                      * activation account, so let's remove it
                      * and let user re-register
@@ -209,7 +209,7 @@ class LoginRegisterController extends LoginController {
     public function getPassword() {
         $passwordField = $this->getProperty('passwordField','password');
         $password = $this->dictionary->get($passwordField);
-        if ($this->getProperty('trimPassword',true,'isset')) {
+        if ($this->getProperty('trimPassword',true)) {
             $password = trim($password);
         }
         return $password;
@@ -344,7 +344,7 @@ class LoginRegisterController extends LoginController {
         $password = $this->getPassword();
         $passwordField = $this->getProperty('passwordField','password');
 
-        $passwordWordSeparator = $this->getProperty('passwordWordSeparator',' ','isset');
+        $passwordWordSeparator = $this->getProperty('passwordWordSeparator',' ');
         if (strlen($passwordWordSeparator) == 0) $passwordWordSeparator = ' ';
         $wordCount = $this->getWordsInString($password,$passwordWordSeparator);
         $minimumStrongPasswordWordCount = $this->getProperty('minimumStrongPasswordWordCount',4,'!empty');

--- a/core/components/login/controllers/web/Register.php
+++ b/core/components/login/controllers/web/Register.php
@@ -98,24 +98,24 @@ class LoginRegisterController extends LoginController {
         }
         $this->validateEmail();
 
-        $placeholderPrefix = $this->getProperty('placeholderPrefix','');
+        $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix', ''), '.');
         if ($this->validator->hasErrors()) {
-            $this->modx->toPlaceholders($this->validator->getErrors(),$placeholderPrefix.'error');
-            $this->modx->setPlaceholder($placeholderPrefix.'validation_error',true);
+            $this->modx->toPlaceholders($this->validator->getErrors(), $placeholderPrefix . '.error');
+            $this->modx->setPlaceholder($placeholderPrefix . '.validation_error', true);
         } else {
 
             $this->loadPreHooks();
 
             /* process hooks */
             if ($this->preHooks->hasErrors()) {
-                $this->modx->toPlaceholders($this->preHooks->getErrors(),$placeholderPrefix.'error');
+                $this->modx->toPlaceholders($this->preHooks->getErrors(), $placeholderPrefix . '.error');
                 $errorMsg = $this->preHooks->getErrorMessage();
-                $this->modx->setPlaceholder($placeholderPrefix.'error.message',$errorMsg);
+                $this->modx->setPlaceholder($placeholderPrefix . '.error.message', $errorMsg);
             } else {
                 /* everything good, go ahead and register */
                 $result = $this->runProcessor('register');
                 if ($result !== true) {
-                    $this->modx->setPlaceholder($placeholderPrefix.'error.message',$result);
+                    $this->modx->setPlaceholder($placeholderPrefix . '.error.message', $result);
                 } else {
                     $this->success = true;
                 }
@@ -123,10 +123,10 @@ class LoginRegisterController extends LoginController {
         }
 
         $placeholders = $this->dictionary->toArray();
-        $this->modx->setPlaceholders($placeholders, $placeholderPrefix);
+        $this->modx->toPlaceholders($placeholders, $placeholderPrefix);
         foreach ($placeholders as $k => $v) {
             if (is_array($v)) {
-                $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
+                $this->modx->setPlaceholder($placeholderPrefix . '.' . $k, json_encode($v));
             }
         }
         return '';
@@ -308,17 +308,19 @@ class LoginRegisterController extends LoginController {
         $mathMinRange = $this->getProperty('mathMinRange',10);
         $op1 = rand($mathMinRange,$mathMaxRange);
         $op2 = rand($mathMinRange,$mathMaxRange);
+        $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix', ''), '.');
         if ($op2 > $op1) { $t = $op2; $op2 = $op1; $op1 = $t; } /* swap so we always get positive #s */
         $operators = array('+','-');
         $operator = rand(0,1);
-        $this->modx->setPlaceholders(array(
+        $this->modx->toPlaceholders(array(
             $this->getProperty('mathOp1Field','op1') => $op1,
             $this->getProperty('mathOp2Field','op2') => $op2,
             $this->getProperty('mathOperatorField','operator') => $operators[$operator],
-        ),$this->getProperty('placeholderPrefix',''));
+        ), $placeholderPrefix);
     }
 
     public function loadReCaptcha() {
+        $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix', ''), '.');
         /** @var reCaptcha $recaptcha */
         $recaptcha = $this->modx->getService('recaptcha','reCaptcha',$this->login->config['modelPath'].'recaptcha/');
         if ($recaptcha instanceof reCaptcha) {
@@ -327,7 +329,7 @@ class LoginRegisterController extends LoginController {
             $recaptchaWidth = $this->getProperty('recaptchaWidth',500);
             $recaptchaHeight = $this->getProperty('recaptchaHeight',300);
             $html = $recaptcha->getHtml($recaptchaTheme,$recaptchaWidth,$recaptchaHeight);
-            $this->modx->setPlaceholder($this->getProperty('placeholderPrefix','').'recaptcha_html',$html);
+            $this->modx->setPlaceholder($placeholderPrefix . '.recaptcha_html', $html);
         } else {
             $this->modx->log(modX::LOG_LEVEL_ERROR,'[Register] '.$this->modx->lexicon('register.recaptcha_err_load'));
         }

--- a/core/components/login/controllers/web/ResetPassword.php
+++ b/core/components/login/controllers/web/ResetPassword.php
@@ -208,9 +208,9 @@ class LoginResetPasswordController extends LoginController {
         $this->loadDictionary();
         $this->errors = $this->validate();
         if (!empty($this->errors)) {
-            $placeholderPrefix = $this->getProperty('placeholderPrefix','logcp.');
-            $this->modx->setPlaceholders($this->errors,$placeholderPrefix.'error.');
-            $this->modx->setPlaceholders($this->dictionary->toArray(),$placeholderPrefix);
+            $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix', 'logcp.'), '.');
+            $this->modx->toPlaceholders($this->errors, $placeholderPrefix . '.error');
+            $this->modx->toPlaceholders($this->dictionary->toArray(), $placeholderPrefix);
 
             return $this->showChangePasswordForm();
         }

--- a/core/components/login/controllers/web/ResetPassword.php
+++ b/core/components/login/controllers/web/ResetPassword.php
@@ -135,7 +135,7 @@ class LoginResetPasswordController extends LoginController {
         } else {
             $this->user->set('password',md5($this->password));
         }
-        if (!$this->getProperty('debug',false,'isset')) {
+        if (!$this->getProperty('debug',false)) {
             $saved = $this->user->save();
         }
         return $saved;

--- a/core/components/login/controllers/web/UpdateProfile.php
+++ b/core/components/login/controllers/web/UpdateProfile.php
@@ -152,14 +152,18 @@ class LoginUpdateProfileController extends LoginController {
      */
     public function setFieldPlaceholders() {
         $placeholders = $this->profile->toArray();
+        $placeholderPrefix = $this->getProperty('placeholderPrefix'));
         /* add extended fields to placeholders */
         if ($this->getProperty('useExtended',true,'isset')) {
             $extended = $this->profile->get('extended');
             if (!empty($extended) && is_array($extended)) {
                 $placeholders = array_merge($extended,$placeholders);
+        $this->modx->toPlaceholders($placeholders, $placeholderPrefix);
+        foreach ($placeholders as $k => $v) {
+            if (is_array($v)) {
+                $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
             }
         }
-        $this->modx->toPlaceholders($placeholders,$this->getProperty('placeholderPrefix'));
     }
 
     /**
@@ -200,9 +204,15 @@ class LoginUpdateProfileController extends LoginController {
         $this->preventDuplicateEmails();
 
         if ($this->validator->hasErrors()) {
+            $placeholders = $this->dictionary->toArray();
             $placeholderPrefix = $this->getProperty('placeholderPrefix');
             $this->modx->toPlaceholders($this->validator->getErrors(),$placeholderPrefix.'error');
-            $this->modx->toPlaceholders($this->dictionary->toArray(),$placeholderPrefix);
+            $this->modx->toPlaceholders($placeholders, $placeholderPrefix);
+            foreach ($placeholders as $k => $v) {
+                if (is_array($v)) {
+                    $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
+                }
+            }
             $errors = array();
 			$es = $this->validator->getErrors();
 			foreach ($es as $key => $error) {

--- a/core/components/login/controllers/web/UpdateProfile.php
+++ b/core/components/login/controllers/web/UpdateProfile.php
@@ -81,7 +81,7 @@ class LoginUpdateProfileController extends LoginController {
                     $result = $this->runProcessor('UpdateProfile');
                     if ($result !== true) {
                         $this->modx->toPlaceholder('message',$result,'error');
-                    } else if ($this->getProperty('reloadOnSuccess',true,'isset')) {
+                    } else if ($this->getProperty('reloadOnSuccess',true)) {
                         $url = $this->modx->makeUrl($this->modx->resource->get('id'),'',array(
                             $this->getProperty('successKey','updpsuccess') => 1,
                         ),'full');
@@ -106,7 +106,7 @@ class LoginUpdateProfileController extends LoginController {
         $authenticated = true;
         if (!$this->modx->user->hasSessionContext($this->modx->context->get('key'))) {
             $authenticated = false;
-            if ($this->getProperty('redirectToLogin',true,'isset')) {
+            if ($this->getProperty('redirectToLogin',true)) {
                 $this->modx->sendUnauthorizedPage();
             }
         }
@@ -268,8 +268,8 @@ class LoginUpdateProfileController extends LoginController {
             $this->loadHooks('preHooks');
             $this->preHooks->loadMultiple($preHooks,$this->dictionary->toArray(),array(
                 'submitVar' => $this->getProperty('submitVar'),
-                'redirectToLogin' => $this->getProperty('redirectToLogin',true,'isset'),
-                'reloadOnSuccess' => $this->getProperty('reloadOnSuccess',true,'isset'),
+                'redirectToLogin' => $this->getProperty('redirectToLogin',true),
+                'reloadOnSuccess' => $this->getProperty('reloadOnSuccess',true),
             ));
             $values = $this->preHooks->getValues();
             if (!empty($values)) {

--- a/core/components/login/controllers/web/UpdateProfile.php
+++ b/core/components/login/controllers/web/UpdateProfile.php
@@ -152,16 +152,18 @@ class LoginUpdateProfileController extends LoginController {
      */
     public function setFieldPlaceholders() {
         $placeholders = $this->profile->toArray();
-        $placeholderPrefix = $this->getProperty('placeholderPrefix'));
+        $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix'), '.');
         /* add extended fields to placeholders */
-        if ($this->getProperty('useExtended',true,'isset')) {
+        if ($this->getProperty('useExtended', true)) {
             $extended = $this->profile->get('extended');
             if (!empty($extended) && is_array($extended)) {
-                $placeholders = array_merge($extended,$placeholders);
+                $placeholders = array_merge($extended, $placeholders);
+            }
+        }
         $this->modx->toPlaceholders($placeholders, $placeholderPrefix);
         foreach ($placeholders as $k => $v) {
             if (is_array($v)) {
-                $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
+                $this->modx->setPlaceholder($placeholderPrefix . '.' . $k, json_encode($v));
             }
         }
     }
@@ -205,12 +207,12 @@ class LoginUpdateProfileController extends LoginController {
 
         if ($this->validator->hasErrors()) {
             $placeholders = $this->dictionary->toArray();
-            $placeholderPrefix = $this->getProperty('placeholderPrefix');
-            $this->modx->toPlaceholders($this->validator->getErrors(),$placeholderPrefix.'error');
+            $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix'), '.');
+            $this->modx->toPlaceholders($this->validator->getErrors(), $placeholderPrefix . '.error');
             $this->modx->toPlaceholders($placeholders, $placeholderPrefix);
             foreach ($placeholders as $k => $v) {
                 if (is_array($v)) {
-                    $this->modx->setPlaceholder($placeholderPrefix . $k, json_encode($v));
+                    $this->modx->setPlaceholder($placeholderPrefix . '.' . $k, json_encode($v));
                 }
             }
             $errors = array();
@@ -218,7 +220,7 @@ class LoginUpdateProfileController extends LoginController {
 			foreach ($es as $key => $error) {
 				$errors['message'] .= $error . $this->getProperty('errorDelimited');
 			}
-			$this->modx->toPlaceholder('message', $errors['message'], $placeholderPrefix.'error');
+            $this->modx->toPlaceholder('message', $errors['message'], $placeholderPrefix . '.error');
         } else {
             $validated = true;
         }

--- a/core/components/login/docs/changelog.txt
+++ b/core/components/login/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog file for Login component.
 
+Login 1.9.3
+====================================
+- Added activePage propetty to ConfirmRegister processor
+
 Login 1.9.2
 ====================================
 - Fix sending register activation email

--- a/core/components/login/docs/readme.txt
+++ b/core/components/login/docs/readme.txt
@@ -1,7 +1,7 @@
 --------------------
 Snippet: Login
 --------------------
-Version: 1.9.2
+Version: 1.9.3
 Since: June 21, 2010
 Author: Jason Coward <jason@modx.com>
         Shaun McCormick <shaun+login@modx.com>

--- a/core/components/login/lexicon/en/properties.inc.php
+++ b/core/components/login/lexicon/en/properties.inc.php
@@ -103,7 +103,8 @@ $_lang['prop_confirmregister.redirectto_desc'] = 'Optional. After a successful c
 $_lang['prop_confirmregister.redirectparams_desc'] = 'Optional. A JSON object of parameters to pass when redirecting using redirectTo.';
 $_lang['prop_confirmregister.authenticate_desc'] = 'Authenticate and login the user to the current context after confirming registration. Defaults to true.';
 $_lang['prop_confirmregister.authenticatecontexts_desc'] = 'Optional. A comma-separated list of contexts to authenticate to. Defaults to the current context.';
-$_lang['prop_confirmregister.errorpage_desc'] = 'Optional. If set, will redirect user to a custom error page if they try to access this page after activating their account.';
+$_lang['prop_confirmregister.errorpage_desc'] = 'Optional. If set, will redirect user to a custom error page if they try to access the confirm register page with some validation error.';
+$_lang['prop_confirmregister.activepage_desc'] = 'Optional. If set, will redirect user to a active error page if they try to access this the confirm register page with an already activated account.';
 
 /* ResetPassword snippet */
 $_lang['prop_resetpassword.tpl_desc'] = 'The reset password message tpl.';

--- a/core/components/login/lexicon/nl/register.inc.php
+++ b/core/components/login/lexicon/nl/register.inc.php
@@ -53,4 +53,4 @@ $_lang['register.spam_blocked'] = 'Uw verzending is geblokkeerd door een spamfil
 $_lang['register.spam_marked'] = ' - gemarkeerd als spam.';
 $_lang['register.user_err_save'] = 'Er is een fout opgetreden bij het opslaan van de gebruiker.';
 $_lang['register.username'] = 'Gebruikersnaam';
-$_lang['register.username_taken'] = 'Gebruikersnaam bestaat reed. Kies een alternatief.';
+$_lang['register.username_taken'] = 'Gebruikersnaam bestaat reeds. Kies een alternatief.';

--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -211,6 +211,7 @@ class Login {
      */
     public function getChunk($name,$properties,$type = 'modChunk') {
         $output = '';
+        if (!is_array($properties)) $properties = array();
         switch ($type) {
             case 'embedded':
                 if (!$this->modx->user->isAuthenticated($this->modx->context->get('key'))) {


### PR DESCRIPTION
### What does it do?

Added a property activePage to the ConfirmRegister processor
### Why is it needed?

At the moment the ConfirmRegister shows the MODX error page or the ConfirmRegister errorPage if the user is already activated. This could be a bit misleading, if the activate link is clicked twice for some reason. Redirecting all ConfirmRegister errors to one error page is also a bit misleading. 

By using the activePage property, all 'real' errors are redirected to an errorPage. The user could be redirected to i.e. a profile page if the user is already activated.
