### PR TITLE
small php7 compat

### DIFF
--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -211,6 +211,7 @@ class Login {
      */
     public function getChunk($name,$properties,$type = 'modChunk') {
         $output = '';
+        if (!is_array($properties)) $properties = array();
         switch ($type) {
             case 'embedded':
                 if (!$this->modx->user->isAuthenticated($this->modx->context->get('key'))) {


### PR DESCRIPTION
Seems in php 7 if `null` is passed to the Login->getChunk method as an argument value, such as in the ResetPassword controller, a server error occurs. Checking for non-array values, and resetting to an empty array, should have the same output but doesn't cause an error. Tested in Cloud (php 5.x still I think) works, so it seems there's not b/c issues, but it also in works in php7.