### PR TITLE
Login via email

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -371,6 +371,12 @@
               "value": "logout"
             },
             {
+              "name": "loginViaEmail",
+              "description": "prop_login.loginviaemail_desc",
+              "type": "combo-boolean",
+              "value": false
+            },
+            {
               "name": "tplType",
               "description": "prop_login.tpltype_desc",
               "type": "list",

--- a/core/components/login/controllers/web/Login.php
+++ b/core/components/login/controllers/web/Login.php
@@ -32,6 +32,7 @@ class LoginLoginController extends LoginController {
 
     public function initialize() {
         $this->setDefaultProperties(array(
+            'loginViaEmail' => false,
             'loginTpl' => 'lgnLoginTpl',
             'logoutTpl' => 'lgnLogoutTpl',
             'loggedinResourceId' => '',
@@ -249,17 +250,24 @@ class LoginLoginController extends LoginController {
      * @return modProcessorResponse
      */
     public function runLoginProcessor() {
+        $loginViaEmail = $this->getProperty('loginViaEmail', false);
+        
         $fields = $this->dictionary->toArray();
         /* send to login processor and handle response */
-        $c = array(
+        $properties = array(
             'login_context' => $this->getProperty('loginContext'),
-            'add_contexts' => $this->getProperty('contexts',''),
-            'username' => $fields['username'],
-            'password' => $fields['password'],
-            'returnUrl' => $fields['returnUrl'],
-            'rememberme' => !empty($fields[$this->getProperty('rememberMeKey','rememberme')]) ? true : false,
+            'add_contexts'  => $this->getProperty('contexts',''),
+            'username'      => $fields['username'],
+            'password'      => $fields['password'],
+            'returnUrl'     => $fields['returnUrl'],
+            'rememberme'    => !empty($fields[$this->getProperty('rememberMeKey','rememberme')]) ? true : false,
         );
-        return $this->modx->runProcessor('security/login',$c);
+        if ($loginViaEmail) {
+            $processorsPath = $this->config['processorsPath'];
+            return $this->modx->runProcessor('customlogin', $properties, array('processors_path' => $processorsPath));
+        } else {
+            return $this->modx->runProcessor('security/login', $properties);
+        }
     }
 
     /**

--- a/core/components/login/elements/snippets/login.snippet.php
+++ b/core/components/login/elements/snippets/login.snippet.php
@@ -31,6 +31,7 @@
  * @property textfield actionKey The REQUEST variable containing the action to take.
  * @property textfield loginKey The actionKey for login.
  * @property textfield logoutKey The actionKey for logout.
+ * @property boolean loginViaEmail Enable login via username or email address (either one!) [default: false]
  * @property list tplType The type of template to expect for the views:
  *  modChunk - name of chunk to use
  *  file - full path to file to use as tpl

--- a/core/components/login/lexicon/de/properties.inc.php
+++ b/core/components/login/lexicon/de/properties.inc.php
@@ -17,6 +17,7 @@ $_lang['prop_forgotpassword.resetresourceid_desc'] = 'Die Ressource-ID zu der Be
 $_lang['prop_login.actionkey_desc'] = 'Die REQUEST Variable die indiziert, welche Aktion ausgeführt werden soll.';
 $_lang['prop_login.loginkey_desc'] = 'Der login-Aktionsschlüssel.';
 $_lang['prop_login.logoutkey_desc'] = 'Der logout-Aktionsschlüssel.';
+$_lang['prop_login.loginviaemail_desc'] = 'Anmeldung mittels Benutzername oder Email Adresse ermöglichen.';
 $_lang['prop_login.tpltype_desc'] = 'Templatetyp für die login und logout Formulare.';
 $_lang['prop_login.logintpl_desc'] = 'Das login Formulartemplate.';
 $_lang['prop_login.logouttpl_desc'] = 'Das logout Formulartemplate.';

--- a/core/components/login/lexicon/en/properties.inc.php
+++ b/core/components/login/lexicon/en/properties.inc.php
@@ -20,6 +20,7 @@ $_lang['prop_forgotpassword.resetresourceid_desc'] = 'The resource to direct use
 $_lang['prop_login.actionkey_desc'] = 'The REQUEST variable that indicates what action to take.';
 $_lang['prop_login.loginkey_desc'] = 'The login action key.';
 $_lang['prop_login.logoutkey_desc'] = 'The logout action key.';
+$_lang['prop_login.loginviaemail_desc'] = 'Enable login via username or email address.';
 $_lang['prop_login.tpltype_desc'] = 'The type of tpls being provided for the login and logout forms.';
 $_lang['prop_login.logintpl_desc'] = 'The login form tpl.';
 $_lang['prop_login.logouttpl_desc'] = 'The logout tpl.';

--- a/core/components/login/processors/customlogin.class.php
+++ b/core/components/login/processors/customlogin.class.php
@@ -35,15 +35,22 @@ class CustomLoginProcessor extends modSecurityLoginProcessor {
      * @return bool|null|string
      */
     public function getUser() {
-        /** @var $user modUser */
-        $this->user = $this->modx->getObjectGraph('modUser', '{"Profile":{},"UserSettings":{}}', array(
-            array(
-                'modUser.username' => $this->username
-            ),
-            array(
-                'OR:Profile.email:=' => $this->username
-            )
+
+        // Only accept login via email address if it exists only once!
+        $count = $this->modx->getCount('modUserProfile', array(
+            'email' => $this->username,
         ));
+        if ($count > 1) {
+            $criteria = array ('modUser.username' => $this->username);
+        } else {
+            $criteria = array(
+                array('modUser.username' => $this->username),
+                array('OR:Profile.email:=' => $this->username)
+            );
+        }
+
+        /** @var $user modUser */
+        $this->user = $this->modx->getObjectGraph('modUser', '{"Profile":{},"UserSettings":{}}', $criteria);
         return $this->fireOnUserNotFoundEvent();
     }
 }

--- a/core/components/login/processors/customlogin.class.php
+++ b/core/components/login/processors/customlogin.class.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Login
+ *
+ * Copyright 2010 by Jason Coward <jason@modx.com> and Shaun McCormick <shaun+login@modx.com>
+ *
+ * Login is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option) any
+ * later version.
+ *
+ * Login is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Login; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * @package login
+ */
+/**
+ * Custom login processor to enable login via username or email address (either one!)
+ *
+ * @package login
+ * @subpackage processors
+ */
+require_once MODX_CORE_PATH.'model/modx/processors/security/login.class.php';
+
+class CustomLoginProcessor extends modSecurityLoginProcessor {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return bool|null|string
+     */
+    public function getUser() {
+        /** @var $user modUser */
+        $this->user = $this->modx->getObjectGraph('modUser', '{"Profile":{},"UserSettings":{}}', array(
+            array(
+                'modUser.username' => $this->username
+            ),
+            array(
+                'OR:Profile.email:=' => $this->username
+            )
+        ));
+        return $this->fireOnUserNotFoundEvent();
+    }
+}
+return 'CustomLoginProcessor';


### PR DESCRIPTION
This PR adds a new feature to accept logins either via username (from modUser) or email address (from modUserProfile).

**Activate this via new snippet property:**

```php
[[!Login?
    &loginViaEmail=`1`
    ...
]]
```

**Built in protection**:
If an email address exists more than once the corresponding users can't login via email address!