### PR TITLE
Added new options and placeholders for the Register snippet to allow AJAX calls.

### DIFF
--- a/core/components/login/controllers/web/Register.php
+++ b/core/components/login/controllers/web/Register.php
@@ -64,6 +64,8 @@ class LoginRegisterController extends LoginController {
             'validate' => '',
             'validatePassword' => true,
             'autoLogin' => false,
+            'validationErrorBulkFormatJson' => false,
+            'validationErrorMessage' => '<p class="error">A form validation error occurred. Please check the values you have entered.</p>',
         ));
     }
 
@@ -101,8 +103,16 @@ class LoginRegisterController extends LoginController {
         $placeholderPrefix = rtrim($this->getProperty('placeholderPrefix', ''), '.');
         $errorPrefix = ($placeholderPrefix) ? $placeholderPrefix . '.error' : 'error';
         if ($this->validator->hasErrors()) {
-            $this->modx->toPlaceholders($this->validator->getErrors(), $errorPrefix);
+            $errors = $this->validator->getErrors();
+            $this->modx->toPlaceholders($errors, $errorPrefix);
             $this->modx->toPlaceholder('validation_error', true, $placeholderPrefix);
+            // Check if JSON bulk output for errors should be set
+            if ($this->getProperty('validationErrorBulkFormatJson')) {
+                // Convert array of errors into JSON formatted string.
+                $jsonErrorOutput = $this->modx->toJSON($errors);
+                $this->modx->toPlaceholder('errors', $jsonErrorOutput, $placeholderPrefix);
+            }
+            $this->modx->toPlaceholder('validation_error_message', $this->getProperty('validationErrorMessage'), $placeholderPrefix);
         } else {
 
             $this->loadPreHooks();
@@ -118,6 +128,8 @@ class LoginRegisterController extends LoginController {
                 if ($result !== true) {
                     $this->modx->toPlaceholder('error.message', $result, $placeholderPrefix);
                 } else {
+                    // Set user specified message if registering is successful.
+                    $this->modx->toPlaceholder('success_msg', $this->getProperty('successMsg'), $placeholderPrefix);
                     $this->success = true;
                 }
             }

--- a/core/components/login/model/login/loginvalidator.class.php
+++ b/core/components/login/model/login/loginvalidator.class.php
@@ -285,7 +285,12 @@ class LoginValidator {
      * @return string The added error message with the error wrapper.
      */
     public function addError($key,$value) {
-        $errTpl = $this->modx->getOption('errTpl',$this->login->config,'<span class="error">[[+error]]</span>');
+        // If jsonResponse is requested, we don't want span tags in our errors by default.
+        if($this->login->config['jsonResponse']){
+            $errTpl = $this->modx->getOption('errTpl',$this->login->config,'[[+error]]');
+        } else {
+            $errTpl = $this->modx->getOption('errTpl',$this->login->config,'<span class="error">[[+error]]</span>');
+        }
         $this->errorsRaw[$key] = $value;
         if (!isset($this->errors[$key])) {
             $this->errors[$key] = '';


### PR DESCRIPTION
Updated to reflect modified PR
----------------------------------------

Inspired by this blog post referring to FormIt: https://www.sepiariver.ca/blog/modx-web/modx-forms-via-ajax/

These changes allow JSON output for success and errors so that the Register snippet can be called via AJAX.

New snippet parameters:

- **&jsonResponse**: Boolean. The default is 0 and if set to 1 the response from the snippet will be encoded JSON. Both error and success responses.
- **&validationErrorMessage**: String. A user can set  their own error message if the call fails due to validation. This will either be included in a JSON error response if selected or can also be output with the [[+validation_error_message]] placeholder.

New placeholder: 

- **[[+validation_error_message]]** : If registration fails due to validation, string from &validationErrorMessage will be output here.


Example setup for an AJAX resource.
=========
```
[[!Register? 
    &jsonResponse=`1`
    &validationErrorMessage=`A form validation error occurred. Please check the values you have entered.`
    &activation=`0`
    &usernameField=`email`
    &generatePassword=`1`
    &validatePassword=`0`
    &successMsg=`User registration was successful!`
    &validate=`fullname:required,
        email:required:email,
        phone:required`
]]
```
