### PR TITLE
Register snippet PII improvements

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -161,6 +161,12 @@
               "value": ""
             },
             {
+              "name": "redirectUnsetDefaultParams",
+              "description": "prop_confirmregister.redirectUnsetDefaultParam_desc",
+              "type": "combo-boolean",
+              "value": false
+            },
+            {
               "name": "authenticate",
               "description": "prop_confirmregister.authenticate_desc",
               "type": "combo-boolean",
@@ -807,6 +813,12 @@
               "description": "prop_register.preservefieldsafterregister_desc",
               "type": "combo-boolean",
               "value": true
+            },
+            {
+              "name": "redirectUnsetDefaultParams",
+              "description": "prop_register.redirectUnsetDefaultParam_desc",
+              "type": "combo-boolean",
+              "value": false
             }
           ]
         },

--- a/core/components/login/controllers/web/Register.php
+++ b/core/components/login/controllers/web/Register.php
@@ -55,6 +55,7 @@ class LoginRegisterController extends LoginController {
             'postHooks' => '',
             'redirectBack' => '',
             'redirectBackParams' => '',
+            'redirectUnsetDefaultParams' => false,
             'submittedResourceId' => '',
             'submitVar' => 'login-register-btn',
             'successMsg' => '',

--- a/core/components/login/lexicon/en/properties.inc.php
+++ b/core/components/login/lexicon/en/properties.inc.php
@@ -89,6 +89,7 @@ $_lang['prop_register.ensurePasswordStrengthSuggestions'] = 'If ensurePasswordSt
 $_lang['prop_register.allowedfields_desc'] = 'If set, will limit the fields that are allowed to be set on the newly created user to this comma-separated list. Also restricts extended fields.';
 $_lang['prop_register.removeexpiredregistrations_desc'] = 'If true, will remove registered users that have an expired, unused activation request and have never activated. It is recommended to leave this on to prevent spam.';
 $_lang['prop_register.preservefieldsafterregister_desc'] = 'If true, data of registration fields will be saved after successfull registration. To reset fields data, set to false';
+$_lang['prop_register.redirectUnsetDefaultParam_desc'] = 'If true, default parameters will be removed from redirected urls.';
 $_lang['opt_register.chunk'] = 'Chunk';
 $_lang['opt_register.file'] = 'File';
 $_lang['opt_register.inline'] = 'Inline';
@@ -103,6 +104,7 @@ $_lang['opt_register.desc'] = 'Descending';
 /* ConfirmRegister snippet */
 $_lang['prop_confirmregister.redirectto_desc'] = 'Optional. After a successful confirmation, redirect to this Resource.';
 $_lang['prop_confirmregister.redirectparams_desc'] = 'Optional. A JSON object of parameters to pass when redirecting using redirectTo.';
+$_lang['prop_confirmregister.redirectUnsetDefaultParam_desc'] = 'If true, default parameters will be removed from redirected urls.';
 $_lang['prop_confirmregister.authenticate_desc'] = 'Authenticate and login the user to the current context after confirming registration. Defaults to true.';
 $_lang['prop_confirmregister.authenticatecontexts_desc'] = 'Optional. A comma-separated list of contexts to authenticate to. Defaults to the current context.';
 $_lang['prop_confirmregister.errorpage_desc'] = 'Optional. If set, will redirect user to a custom error page if they try to access the confirm register page with some validation error.';

--- a/core/components/login/processors/register.php
+++ b/core/components/login/processors/register.php
@@ -122,12 +122,12 @@ class LoginRegisterProcessor extends LoginProcessor {
         $userGroupField = $this->controller->getProperty('usergroupsField','');
         foreach ($fields as $field => $value) {
             if (!isset($profileFields[$field])
-                    && !isset($userFields[$field])
-                    && $field != 'password_confirm'
-                    && $field != 'passwordconfirm'
-                    && $field != $userGroupField
-                    && !in_array($field,$excludeExtended)
-                    ) {
+                && !isset($userFields[$field])
+                && $field != 'password_confirm'
+                && $field != 'passwordconfirm'
+                && $field != $userGroupField
+                && !in_array($field,$excludeExtended)
+               ) {
                 $extended[$field] = $value;
             }
         }
@@ -376,10 +376,12 @@ class LoginRegisterProcessor extends LoginProcessor {
         if (!empty($moderated)) {
             $moderatedResourceId = $this->controller->getProperty('moderatedResourceId','');
             if (!empty($moderatedResourceId)) {
-                $persistParams = array_merge($this->persistParams,array(
-                    'username' => $this->user->get('username'),
-                    'email' => $this->profile->get('email'),
-                ));
+                if ($this->controller->getProperty('redirectUnsetDefaultParams') == false) {
+                    $persistParams = array_merge($this->persistParams,array(
+                        'username' => $this->user->get('username'),
+                        'email' => $this->profile->get('email'),
+                    ));
+                }
                 $url = $this->modx->makeUrl($moderatedResourceId,'',$persistParams,'full');
                 if (!$this->login->inTestMode) {
                     $this->modx->sendRedirect($url);
@@ -400,10 +402,12 @@ class LoginRegisterProcessor extends LoginProcessor {
          * GET params `username` and `email` for you to use */
         $submittedResourceId = $this->controller->getProperty('submittedResourceId','');
         if (!empty($submittedResourceId)) {
-            $persistParams = array_merge($this->persistParams,array(
-                'username' => $this->user->get('username'),
-                'email' => $this->profile->get('email'),
-            ));
+            if ($this->controller->getProperty('redirectUnsetDefaultParams') == false) {
+                $persistParams = array_merge($this->persistParams,array(
+                    'username' => $this->user->get('username'),
+                    'email' => $this->profile->get('email'),
+                ));
+            }
             $url = $this->modx->makeUrl($submittedResourceId,'',$persistParams,'full');
             if (!$this->login->inTestMode) {
                 $this->modx->sendRedirect($url);


### PR DESCRIPTION
### Summary
Makes the setting of 'username' and 'email' url params optional by adding ```&redirectUnsetDefaultParams=`1` ``` to your Register snippet call. Addresses https://github.com/modxcms/Login/issues/122


### Reason
Essential for GDPR and Google Analytics T&C compliance.   
### Changes
- Add &redirectUnsetDefaultParams to Register snippet
- Allow &redirectUnsetDefaultParams to disable the setting of pii params in redirect urls
- Add &redirectUnsetDefaultParams to default property sets for Register and ConfirmRegister snippets
- Add desc to lexicons