### PR TITLE
generatePassword improvement

### DIFF
--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -185,18 +185,8 @@ class Login {
      * @param integer $length The length of the generated password.
      * @return string The newly-generated password.
      */
-    public function generatePassword($length=8) {
-        $pword = '';
-        $charmap = '0123456789bcdfghjkmnpqrstvwxyz';
-        $i = 0;
-        while ($i < $length) {
-            $char = substr($charmap, rand(0, strlen($charmap)-1), 1);
-            if (!strstr($pword, $char)) {
-                $pword .= $char;
-                $i++;
-            }
-        }
-        return $pword;
+    public function generatePassword($length=null) {
+        $this->modx->user->generatePassword($length);
     }
 
     /**


### PR DESCRIPTION
### What does it do?
We should use the generatePassword function MODX provides us.

### Why is it needed?
In MODX I improved the generatePassword method. PR: https://github.com/modxcms/revolution/pull/13909 

When generating a password it's better to adhere to the MODX settings, therefore we should use the generatePassword function MODX provides us.

### Related issue(s)/PR(s)
It solves issue #69 
