### PR TITLE
fix problem "activation link again"

### DIFF
--- a/core/components/login/controllers/web/ConfirmRegister.php
+++ b/core/components/login/controllers/web/ConfirmRegister.php
@@ -113,7 +113,7 @@ class LoginConfirmRegisterController extends LoginController {
      * @param mixed $id Resource ID to redirect to
      */
     public function redirectAfterFailure($id = null) {
-        $errorPage = (is_null($id)) ? $this->getProperty('errorPage', false, 'isset') : $id;
+        $errorPage = (empty($id)) ? $this->getProperty('errorPage', false, 'isset') : $id;
         if (!empty($errorPage)) {
             $url = $this->modx->makeUrl($errorPage,'','','full');
             $this->modx->sendRedirect($url);


### PR DESCRIPTION
The problem occurs when you click the activation link again.

1. activePage property not set
2. line 105: activePage =""
3. line 116: 
is_null ----- $errorPage = "" ------ endless cycle
my fix ----- $errorPage = property errorPage------OK

ps need fix https://docs.modx.com/extras/revo/login/login.confirmregister
activePage property not described