### PR TITLE
Secure lgnactivateemailtpl.chunk.tpl

### DIFF
--- a/core/components/login/elements/chunks/lgnactivateemailtpl.chunk.tpl
+++ b/core/components/login/elements/chunks/lgnactivateemailtpl.chunk.tpl
@@ -4,12 +4,6 @@
 
 <p><a href="[[+confirmUrl]]">[[+confirmUrl]]</a></p>
 
-<p>After activating, you may login with your password and username:</p>
-
-<p>
-Username: <strong>[[+username]]</strong><br />
-Password: <strong>[[+password]]</strong></p>
-
 <p>If you did not request this message, please ignore it.</p>
 
 <p>Thanks,<br />


### PR DESCRIPTION
I've removed the plaintext credentials from the activation email. Sending plaintext credentials is poor practice and will harm the reputation of site owners who send registration confirmations out with them for all to see. Nobody expects to have their credentials sent back to them upon registration in 2019.