### PR TITLE
added expiredTplType

### DIFF
--- a/core/components/login/controllers/web/ResetPassword.php
+++ b/core/components/login/controllers/web/ResetPassword.php
@@ -51,6 +51,7 @@ class LoginResetPasswordController extends LoginController {
             'autoLogin' => false,
             'forceChangePassword' => false,
             'expiredTpl' => 'lgnExpiredTpl',
+            'expiredTplType' => 'modChunk',
         ));
         $this->modx->lexicon->load('login:profile');
         $this->modx->lexicon->load('login:register');
@@ -63,8 +64,8 @@ class LoginResetPasswordController extends LoginController {
      */
     public function process() {
         $this->getUser();
-        if (empty($this->user)) return $this->modx->getChunk($this->getProperty('expiredTpl'));
-        if (!$this->verifyIdentity()) return $this->modx->getChunk($this->getProperty('expiredTpl'));
+        if (empty($this->user)) return $this->login->getChunk($this->getProperty('expiredTpl'),array(),$this->getProperty('expiredTplType','modChunk'));
+        if (!$this->verifyIdentity()) return $this->login->getChunk($this->getProperty('expiredTpl'),array(),$this->getProperty('expiredTplType','modChunk'));
 
         if ($this->getProperty('forceChangePassword') == true) {
             if (!empty($_POST) && isset($_POST[$this->getProperty('submitVar','logcp-submit')])) {


### PR DESCRIPTION
This adds the possibility to use an inline template for the ResetPassword snippet for expired requests.

Usage:
```
[[!ResetPassword?
    &...
    &expiredTplType=`inline`
    &expiredTpl=`<p>This request expired...</p>`
]]
```