### PR TITLE
fixed fieldConfirmNewPassword

### DIFF
--- a/core/components/login/controllers/web/ChangePassword.php
+++ b/core/components/login/controllers/web/ChangePassword.php
@@ -293,7 +293,7 @@ class LoginChangePasswordController extends LoginController {
      */
     public function confirmMatchedPasswords() {
         $validated = true;
-        $fieldConfirmNewPassword = $this->getProperty('fieldConfirmNewPassword','password_new_confirm');
+        $fieldConfirmNewPassword = $this->getProperty('fieldConfirmNewPassword');
         /* if using confirm, ensure they match */
         if (!empty($fieldConfirmNewPassword)) {
             $confirmNewPassword = $this->dictionary->get($fieldConfirmNewPassword);

--- a/core/components/login/controllers/web/ResetPassword.php
+++ b/core/components/login/controllers/web/ResetPassword.php
@@ -266,7 +266,7 @@ class LoginResetPasswordController extends LoginController {
      */
     public function confirmMatchedPasswords() {
         $validated = true;
-        $fieldConfirmNewPassword = $this->getProperty('fieldConfirmNewPassword','password_new_confirm');
+        $fieldConfirmNewPassword = $this->getProperty('fieldConfirmNewPassword');
         /* if using confirm, ensure they match */
         if (!empty($fieldConfirmNewPassword)) {
             $confirmNewPassword = $this->dictionary->get($fieldConfirmNewPassword);


### PR DESCRIPTION
In both cases the fallback to `password_new_confirm` is already set in the initialize function.

This allows to set a new password without a password repeat field.

Usage:
```
[[!ChangePassword?
    &...
    &fieldConfirmNewPassword=``
]]
```
and
```
[[!ResetPassword?
    &...
    &fieldConfirmNewPassword=``
]]