### PR TITLE
added scriptProperties emailSender, emalFrom, emailFromName and emailReplyTo

### DIFF
--- a/core/components/login/controllers/web/ForgotPassword.php
+++ b/core/components/login/controllers/web/ForgotPassword.php
@@ -57,6 +57,10 @@ class LoginForgotPasswordController extends LoginController {
             'redirectTo' => false,
             'redirectParams' => '',
             'submitVar' => 'login_fp_service',
+            'emailFrom' => '',
+            'emailFromName' => '',
+            'emailSender' => '',
+            'emailReplyTo' => '',
         ));
     }
 
@@ -222,6 +226,10 @@ class LoginForgotPasswordController extends LoginController {
         $emailProperties['tpl'] = $this->getProperty('emailTpl');
         $emailProperties['tplAlt'] = $this->getProperty('emailTplAlt','');
         $emailProperties['tplType'] = $this->getProperty('emailTplType');
+        $emailProperties['emailFrom'] = $this->getProperty('emailFrom');
+        $emailProperties['emailFromName'] = $this->getProperty('emailFromName');
+        $emailProperties['emailSender'] = $this->getProperty('emailSender');
+        $emailProperties['emailReplyTo'] = $this->getProperty('emailReplyTo');
 
         /* now set new password to cache to prevent middleman attacks */
         $this->modx->cacheManager->set('login/resetpassword/'.md5($fields['id'].':'.$fields['username']),$password);

--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -160,15 +160,18 @@ class Login {
 
         $this->modx->getService('mail', 'mail.modPHPMailer');
         $this->modx->mail->set(modMail::MAIL_BODY, $msg);
-        $this->modx->mail->set(modMail::MAIL_FROM, $this->modx->getOption('emailsender'));
-        $this->modx->mail->set(modMail::MAIL_FROM_NAME, $this->modx->getOption('site_name'));
-        $this->modx->mail->set(modMail::MAIL_SENDER, $this->modx->getOption('emailsender'));
+        $this->modx->mail->set(modMail::MAIL_FROM, $this->modx->getOption('emailFrom', $properties, $this->modx->getOption('emailsender'), true));
+        $this->modx->mail->set(modMail::MAIL_FROM_NAME, $this->modx->getOption('emailFromName', $properties, $this->modx->getOption('site_name'), true));
+        $this->modx->mail->set(modMail::MAIL_SENDER, $this->modx->getOption('emailSender', $properties, $this->modx->getOption('emailsender'), true));
         $this->modx->mail->set(modMail::MAIL_SUBJECT, $subject);
         if (!empty($msgAlt)) {
             $this->modx->mail->set(modMail::MAIL_BODY_TEXT, $msgAlt);
         }
         $this->modx->mail->address('to', $email, $name);
-        $this->modx->mail->address('reply-to', $this->modx->getOption('emailsender'));
+        $replyTo = $this->modx->getOption('emailReplyTo', $properties);
+        if (!empty($replyTo)) {
+            $this->modx->mail->address('reply-to', $replyTo);
+        }
         $this->modx->mail->setHTML(true);
         if ($this->inTestMode) return true;
         $sent = $this->modx->mail->send();


### PR DESCRIPTION
This lets you specify emailSender, emailFrom, emailFromName and emailReplyTo for the ForgotPassword emails.

emailSender defaults to system setting `emailsender`
emailFrom defaults to system setting `emailsender`
emailFromName defaults to system setting `site_name`
emailReplyTo no default

Usage:

```
[[!ForgotPassword?
    &...
    &emailSender=`email@sender.com`
    &emailFrom=`email@from.com`
    &emailFromName=`Email From Name`
    &emailReplyTo=`email@replyto.com`
]]
```