### PR TITLE
Log error if mail was not sent

### DIFF
--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -178,6 +178,9 @@ class Login {
         $sent = $this->modx->mail->send();
         $this->modx->mail->reset();
 
+        if (!$sent) {
+            $this->modx->log(\modX::LOG_LEVEL_ERROR, '[Login] '.$this->modx->lexicon('register.email_not_sent').' '.print_r($this->modx->mail->mailer->ErrorInfo, true));
+        }
 
         return $sent;
     }

--- a/core/components/login/model/login/login.class.php
+++ b/core/components/login/model/login/login.class.php
@@ -179,7 +179,7 @@ class Login {
         $this->modx->mail->reset();
 
         if (!$sent) {
-            $this->modx->log(\modX::LOG_LEVEL_ERROR, '[Login] '.$this->modx->lexicon('register.email_not_sent').' '.print_r($this->modx->mail->mailer->ErrorInfo, true));
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[Login] '.$this->modx->lexicon('register.email_not_sent').' '.print_r($this->modx->mail->mailer->ErrorInfo, true));
         }
 
         return $sent;


### PR DESCRIPTION
I ran into an insidious issue, where no activation email was sent and no error could be found anywhere.

FormIt was working fine, so I compared the send mail functions in both extras. Turns out, Login doesn't log anything on failure, so I borrowed that part from FormIt. That got me the error I needed.

FWIW, my issue was an incorrect emailsender value:
```
[2021-06-04 06:33:49] (ERROR @ /home/hugo/Localhost/pff/core/components/login/model/login/login.class.php : 181) [Login] An error occurred while trying to send the email. Invalid address:  (punyEncode) mail@[[++http_host]]
```

I was being "smart" by using http_host (which is always domain.tld) for base installations. FormIt doesn't mind, but Login is less forgiving.