### PR TITLE
Fix loginViaEmail for MODX 3

### DIFF
--- a/core/components/login/processors/customlogin.class.php
+++ b/core/components/login/processors/customlogin.class.php
@@ -25,9 +25,15 @@
  * @package login
  * @subpackage processors
  */
-require_once MODX_CORE_PATH.'model/modx/processors/security/login.class.php';
+$isMODX3 = $this->getVersionData()['version'] >= 3;
+if ($isMODX3) {
+    abstract class DynamicBaseSecurityLoginProcessor extends \MODX\Revolution\Processors\Security\Login {}
+} else {
+    require_once MODX_CORE_PATH.'model/modx/processors/security/login.class.php';
+    abstract class DynamicBaseSecurityLoginProcessor extends modSecurityLoginProcessor {}
+}
 
-class CustomLoginProcessor extends modSecurityLoginProcessor {
+class CustomLoginProcessor extends DynamicBaseSecurityLoginProcessor {
 
     /**
      * {@inheritDoc}

--- a/core/components/login/processors/customlogin.class.php
+++ b/core/components/login/processors/customlogin.class.php
@@ -25,15 +25,13 @@
  * @package login
  * @subpackage processors
  */
-$isMODX3 = $this->getVersionData()['version'] >= 3;
-if ($isMODX3) {
-    abstract class DynamicBaseSecurityLoginProcessor extends \MODX\Revolution\Processors\Security\Login {}
-} else {
+if (file_exists(MODX_CORE_PATH.'model/modx/processors/security/login.class.php')) {
     require_once MODX_CORE_PATH.'model/modx/processors/security/login.class.php';
-    abstract class DynamicBaseSecurityLoginProcessor extends modSecurityLoginProcessor {}
+} elseif (!class_exists('modSecurityLoginProcessor')) {
+    class_alias(\MODX\Revolution\Processors\Security\Login::class, \modSecurityLoginProcessor::class);
 }
 
-class CustomLoginProcessor extends DynamicBaseSecurityLoginProcessor {
+class CustomLoginProcessor extends modSecurityLoginProcessor {
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
In MODX 3 the Login snippet throws an error if the property `loginViaEmail` is set to `1`.

```
PHP Fatal error: require_once(): Failed opening required '/path/to/core/model/modx/processors/security/login.class.php' in /path/to/core/components/login/processors/customlogin.class.php on line 28
```

Related topic in the MODX forum: https://community.modx.com/t/login-extra-in-modx3-not-working-remedy/5789