### PR TITLE
Fix ensurePasswordStrength for Register

### DIFF
--- a/core/components/login/controllers/web/Register.php
+++ b/core/components/login/controllers/web/Register.php
@@ -442,12 +442,13 @@ class LoginRegisterController extends LoginController {
      */
     public function getPossibleStrongerPasswords($password) {
         $passwordLength = strlen($password);
-        if ($passwordLength == 1) return isset($this->strongPasswordMap[$password]) ? $this->strongPasswordMap[$password] : $password;
+        if ($passwordLength == 0) return array();
+        if ($passwordLength == 1) return isset($this->strongPasswordMap[$password]) ? $this->strongPasswordMap[$password] : array($password);
 
         $rest = $this->getPossibleStrongerPasswords(substr($password,1));
         $restLength = count($rest);
 
-        $current = isset($this->strongPasswordMap[$password[0]]) ? $this->strongPasswordMap[$password[0]] : null;
+        $current = isset($this->strongPasswordMap[$password[0]]) ? $this->strongPasswordMap[$password[0]] : array();
         $currentLength = count($current);
         $result = array();
 


### PR DESCRIPTION
Calling Register with the property `` &ensurePasswordStrength=`1` `` and an empty password creates an error because of the `substr` in this line:

https://github.com/modxcms/Login/blob/bcb5ec24e33e24d85695d2c6aaccd119308ed9fc/core/components/login/controllers/web/Register.php#L447

---

This PR also fixes warnings (`PHP warning: count(): Parameter must be an array or an object that implements Countable`) because `count()` is used on `null` and strings.

---

Related topic in the forum: https://community.modx.com/t/register-mail-to-cc/5894/19