### PR TITLE
feat: Option to disallow usergroup and role combinations

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -574,6 +574,11 @@
               "value": ""
             },
             {
+              "name": "usergroupsFieldDisallow",
+              "description": "prop_register.usergroupsfielddisallow_desc",
+              "value": "Administrator"
+            },
+            {
               "name": "submittedResourceId",
               "description": "prop_register.submittedresourceid_desc",
               "value": ""

--- a/_build/config.json
+++ b/_build/config.json
@@ -579,6 +579,10 @@
               "value": "Administrator"
             },
             {
+              "name": "usergroupsFieldAllow",
+              "description": "prop_register.usergroupsfieldallow_desc"
+            },
+            {
               "name": "submittedResourceId",
               "description": "prop_register.submittedresourceid_desc",
               "value": ""

--- a/core/components/login/lexicon/en/properties.inc.php
+++ b/core/components/login/lexicon/en/properties.inc.php
@@ -70,6 +70,7 @@ $_lang['prop_register.submitvar_desc'] = 'The var to check for to load the Regis
 $_lang['prop_register.usergroups_desc'] = 'Optional. A comma-separated list of User Group names or IDs to add the newly-registered User to.';
 $_lang['prop_register.usergroupsfield_desc'] = 'The name of the field to use to specify the User Group(s) to automatically add the new User to. Only used if this value is not blank.';
 $_lang['prop_register.usergroupsfielddisallow_desc'] = 'Optional. A comma-separated list of User Group names or IDs to prevent the newly-registered User from being added to. Only used if this value is not blank.';
+$_lang['prop_register.usergroupsfieldallow_desc'] = 'Optional. A comma-separated allowlist of User Group names or IDs the newly-registered User can be added to. Only used if this value is not blank.';
 $_lang['prop_register.submittedresourceid_desc'] = 'If set, will redirect to the specified Resource after the User submits the registration form.';
 $_lang['prop_register.usernamefield_desc'] = 'The name of the field to use for the new User’s username.';
 $_lang['prop_register.passwordfield_desc'] = 'The name of the field to use for the new User’s password.';

--- a/core/components/login/lexicon/en/properties.inc.php
+++ b/core/components/login/lexicon/en/properties.inc.php
@@ -69,6 +69,7 @@ $_lang['prop_profile.useextended_desc'] = 'Whether or not to set any extra field
 $_lang['prop_register.submitvar_desc'] = 'The var to check for to load the Register functionality. If empty or set to false, Register will process the form on all POST requests.';
 $_lang['prop_register.usergroups_desc'] = 'Optional. A comma-separated list of User Group names or IDs to add the newly-registered User to.';
 $_lang['prop_register.usergroupsfield_desc'] = 'The name of the field to use to specify the User Group(s) to automatically add the new User to. Only used if this value is not blank.';
+$_lang['prop_register.usergroupsfielddisallow_desc'] = 'Optional. A comma-separated list of User Group names or IDs to prevent the newly-registered User from being added to. Only used if this value is not blank.';
 $_lang['prop_register.submittedresourceid_desc'] = 'If set, will redirect to the specified Resource after the User submits the registration form.';
 $_lang['prop_register.usernamefield_desc'] = 'The name of the field to use for the new User’s username.';
 $_lang['prop_register.passwordfield_desc'] = 'The name of the field to use for the new User’s password.';

--- a/core/components/login/processors/register.php
+++ b/core/components/login/processors/register.php
@@ -167,7 +167,8 @@ class LoginRegisterProcessor extends LoginProcessor {
         $userGroupsField = $this->controller->getProperty('usergroupsField','');
         $userGroups = !empty($userGroupsField) && array_key_exists($userGroupsField,$fields) ? $fields[$userGroupsField] : array();
         $userGroupsFieldDisallow = $this->controller->getProperty('usergroupsFieldDisallow','Administrator');
-        $this->setUserGroups($userGroups, $userGroupsFieldDisallow);
+        $userGroupsFieldAllow = $this->controller->getProperty('usergroupsFieldAllow','');
+        $this->setUserGroups($userGroups, $userGroupsFieldDisallow, $userGroupsFieldAllow);
     }
 
     /**
@@ -199,14 +200,16 @@ class LoginRegisterProcessor extends LoginProcessor {
      * @param string $userGroups
      * @return array
      */
-    public function setUserGroups($userGroups, $userGroupsFieldDisallow = 'Administrator') {
+    public function setUserGroups($userGroups, $userGroupsFieldDisallow = 'Administrator', $userGroupsFieldAllow = '') {
         $added = array();
         /* if $userGroups set in form, override here; otherwise use snippet property */
         $this->userGroups = !empty($userGroups) ? $userGroups : $this->controller->getProperty('usergroups', '');
         if (!empty($this->userGroups)) {
             $this->userGroups = is_array($this->userGroups) ? $this->userGroups : explode(',',$this->userGroups);
-            $disallowed = $this->getUserGroupsDisallowed($userGroupsFieldDisallow);
+            $disallowed = $this->getUserGroups($userGroupsFieldDisallow);
             $disallowedKeys = array_keys($disallowed);
+            $allowed = $this->getUserGroups($userGroupsFieldAllow);
+            $allowedKeys = array_keys($allowed);
 
             foreach ($this->userGroups as $userGroupMeta) {
                 $userGroupMeta = explode(':',$userGroupMeta);
@@ -236,6 +239,21 @@ class LoginRegisterProcessor extends LoginProcessor {
                         }
                     } else {
                         continue;
+                    }
+                }
+
+                if (!empty($allowedKeys)) {
+                    if (!in_array($userGroup->get('name'), $allowedKeys, true)  &&
+                        !in_array($userGroup->get('id'), $allowedKeys, true)) {
+                        continue;
+                    }
+                    $allowKey = in_array($userGroup->get('name'), $allowedKeys, true) ?
+                        $userGroup->get('name') : $userGroup->get('id');
+                    $allowRank = $allowed[$allowKey];
+                    if ($allowRank) {
+                        if ($role && ($role->get('rank') < $allowRank)) {
+                            continue;
+                        }
                     }
                 }
 
@@ -464,7 +482,7 @@ class LoginRegisterProcessor extends LoginProcessor {
         return true;
     }
 
-    private function getUserGroupsDisallowed($userGroupsFieldDisallow): array
+    private function getUserGroups($userGroupsFieldDisallow): array
     {
         $userGroupsDisallowed = array();
         $userGroupsFieldDisallow = is_array($userGroupsFieldDisallow) ?
@@ -478,8 +496,8 @@ class LoginRegisterProcessor extends LoginProcessor {
                 $role = $this->modx->getObject('modUserGroupRole', $role_pk);
                 if ($role) {
                     $rank = $role->get('rank');
-                } else if ((int) $groupRole[1]> 0) {
-                    $rank = (int) $groupRole[1] ;
+                } else if ((int) $groupRole[1] > 0) {
+                    $rank = (int) $groupRole[1];
                 }
             }
             $userGroupsDisallowed[$groupRole[0]] = $rank;

--- a/core/components/login/processors/register.php
+++ b/core/components/login/processors/register.php
@@ -166,7 +166,8 @@ class LoginRegisterProcessor extends LoginProcessor {
         /* add user groups, if set */
         $userGroupsField = $this->controller->getProperty('usergroupsField','');
         $userGroups = !empty($userGroupsField) && array_key_exists($userGroupsField,$fields) ? $fields[$userGroupsField] : array();
-        $this->setUserGroups($userGroups);
+        $userGroupsFieldDisallow = $this->controller->getProperty('usergroupsFieldDisallow','Administrator');
+        $this->setUserGroups($userGroups, $userGroupsFieldDisallow);
     }
 
     /**
@@ -198,12 +199,14 @@ class LoginRegisterProcessor extends LoginProcessor {
      * @param string $userGroups
      * @return array
      */
-    public function setUserGroups($userGroups) {
+    public function setUserGroups($userGroups, $userGroupsFieldDisallow = 'Administrator') {
         $added = array();
         /* if $userGroups set in form, override here; otherwise use snippet property */
         $this->userGroups = !empty($userGroups) ? $userGroups : $this->controller->getProperty('usergroups', '');
         if (!empty($this->userGroups)) {
             $this->userGroups = is_array($this->userGroups) ? $this->userGroups : explode(',',$this->userGroups);
+            $disallowed = $this->getUserGroupsDisallowed($userGroupsFieldDisallow);
+            $disallowedKeys = array_keys($disallowed);
 
             foreach ($this->userGroups as $userGroupMeta) {
                 $userGroupMeta = explode(':',$userGroupMeta);
@@ -220,6 +223,22 @@ class LoginRegisterProcessor extends LoginProcessor {
                 $rolePk = !empty($userGroupMeta[1]) ? $userGroupMeta[1] : 'Member';
                 /** @var modUserGroupRole $role */
                 $role = $this->modx->getObject('modUserGroupRole',array('name' => $rolePk));
+
+                /* check if role is disallowed */
+                if (in_array($userGroup->get('name'), $disallowedKeys, true) ||
+                    in_array($userGroup->get('id'), $disallowedKeys, true)) {
+                    $disallowedKey = in_array($userGroup->get('name'), $disallowedKeys, true) ?
+                        $userGroup->get('name') : $userGroup->get('id');
+                    $disallowedRank = $disallowed[$disallowedKey];
+                    if ($disallowedRank) {
+                        if ($role && ($role->get('rank') < $disallowedRank)) {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+
 
                 /* create membership */
                 /** @var modUserGroupMember $member */
@@ -443,6 +462,29 @@ class LoginRegisterProcessor extends LoginProcessor {
         $a = $this->modx->runProcessor('security/login',$c);
 
         return true;
+    }
+
+    private function getUserGroupsDisallowed($userGroupsFieldDisallow): array
+    {
+        $userGroupsDisallowed = array();
+        $userGroupsFieldDisallow = is_array($userGroupsFieldDisallow) ?
+            $userGroupsFieldDisallow : explode(',',$userGroupsFieldDisallow);
+        foreach ($userGroupsFieldDisallow as $userGroupDisallow) {
+            $groupRole = explode(':',$userGroupDisallow);
+            $rank = 0;
+            if (empty($groupRole[0])) continue;
+            if (isset($groupRole[1]) && !empty($groupRole[1])) {
+                $role_pk = (int) $groupRole[1] > 0 ? ['id' => (int) $groupRole[1]] : ['name' => $groupRole[1]];
+                $role = $this->modx->getObject('modUserGroupRole', $role_pk);
+                if ($role) {
+                    $rank = $role->get('rank');
+                } else if ((int) $groupRole[1]> 0) {
+                    $rank = (int) $groupRole[1] ;
+                }
+            }
+            $userGroupsDisallowed[$groupRole[0]] = $rank;
+        }
+        return $userGroupsDisallowed;
     }
 }
 return 'LoginRegisterProcessor';


### PR DESCRIPTION
This adds a new `usergroupsFieldDisallow` verifier option to limit which groups a user can register for when using the `usergroupsField` option. 